### PR TITLE
Allow tapping on the whole NavButton

### DIFF
--- a/lib/src/nav_button.dart
+++ b/lib/src/nav_button.dart
@@ -17,6 +17,7 @@ class NavButton extends StatelessWidget {
     final opacity = length * difference;
     return Expanded(
       child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
         onTap: () {
           onTap(index);
         },


### PR DESCRIPTION
Allow tapping on the whole NavButton other than only on the child.

`behavior: HitTestBehavior.translucent,`
This simple change allows the GestureDetector to detect taps also on the translucent part of the screen. This makes it easier for users to click on the NavButton for example when the icon is very small.