### PR TITLE
Updated curved_navigation_bar.dart to center items

### DIFF
--- a/lib/curved_navigation_bar.dart
+++ b/lib/curved_navigation_bar.dart
@@ -146,7 +146,7 @@ class CurvedNavigationBarState extends State<CurvedNavigationBar>
                     position: _pos,
                     length: _length,
                     index: widget.items.indexOf(item),
-                    child: item,
+                    child: Center(child: item),
                   );
                 }).toList())),
           ),


### PR DESCRIPTION
Within the CurvedNavigationBar, centering all items (icons). Doing so, because FontAwesomeIcons display offset to the top-left. 

Addresses Issue #65