### PR TITLE
Fix animation when switching between items

### DIFF
--- a/lib/curved_navigation_bar.dart
+++ b/lib/curved_navigation_bar.dart
@@ -171,6 +171,9 @@ class CurvedNavigationBarState extends State<CurvedNavigationBar>
     if (widget.onTap != null) {
       widget.onTap!(index);
     }
+    if (_animationController.isAnimating) {
+      return;
+    }
     final newPosition = index / _length;
     setState(() {
       _startingPos = _pos;

--- a/lib/curved_navigation_bar.dart
+++ b/lib/curved_navigation_bar.dart
@@ -165,14 +165,11 @@ class CurvedNavigationBarState extends State<CurvedNavigationBar>
   }
 
   void _buttonTap(int index) {
-    if (!widget.letIndexChange(index)) {
+    if (!widget.letIndexChange(index) && _animationController.isAnimating) {
       return;
     }
     if (widget.onTap != null) {
       widget.onTap!(index);
-    }
-    if (_animationController.isAnimating) {
-      return;
     }
     final newPosition = index / _length;
     setState(() {


### PR DESCRIPTION
If you clicked the same icon after the animation started, it tried to reset the animation all the time, making it bounce from the point it already is.

With this we avoid that by not making it possible to animate the same item again.