### PR TITLE
Limiting the width & Removing the side leftovers from the menu

### DIFF
--- a/lib/curved_navigation_bar.dart
+++ b/lib/curved_navigation_bar.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:meta/meta.dart';
 import 'src/nav_button.dart';
 import 'src/nav_custom_painter.dart';
 
@@ -16,6 +15,7 @@ class CurvedNavigationBar extends StatefulWidget {
   final Curve animationCurve;
   final Duration animationDuration;
   final double height;
+  final double maxWidth;
 
   CurvedNavigationBar({
     Key? key,
@@ -29,9 +29,12 @@ class CurvedNavigationBar extends StatefulWidget {
     this.animationCurve = Curves.easeOut,
     this.animationDuration = const Duration(milliseconds: 600),
     this.height = 75.0,
+    required this.maxWidth,
   })  : letIndexChange = letIndexChange ?? ((_) => true),
-        assert(items != null),
-        assert(items.length >= 1),
+      //  assert(items != null),
+        assert(items.isNotEmpty),
+        //assert(items.length >= 1),
+        assert(items.length > 2),
         assert(0 <= index && index < items.length),
         assert(0 <= height && height <= 75.0),
         super(key: key);
@@ -92,8 +95,12 @@ class CurvedNavigationBarState extends State<CurvedNavigationBar>
 
   @override
   Widget build(BuildContext context) {
-    Size size = MediaQuery.of(context).size;
+    double widthScreeen = MediaQuery.of(context).size.width;
+    double newWidth =
+        widget.maxWidth > widthScreeen ? widthScreeen : widget.maxWidth;
+
     return Container(
+      width: newWidth,
       color: widget.backgroundColor,
       height: widget.height,
       child: Stack(
@@ -104,11 +111,11 @@ class CurvedNavigationBarState extends State<CurvedNavigationBar>
             bottom: -40 - (75.0 - widget.height),
             left: Directionality.of(context) == TextDirection.rtl
                 ? null
-                : _pos * size.width,
-            right: Directionality.of(context) == TextDirection.rtl
+                : _pos * newWidth,
+            /* right: Directionality.of(context) == TextDirection.rtl
                 ? _pos * size.width
-                : null,
-            width: size.width / _length,
+                : null, */
+            width: newWidth / _length,
             child: Center(
               child: Transform.translate(
                 offset: Offset(

--- a/lib/src/nav_custom_painter.dart
+++ b/lib/src/nav_custom_painter.dart
@@ -20,8 +20,11 @@ class NavCustomPainter extends CustomPainter {
       ..color = color
       ..style = PaintingStyle.fill;
 
+
     final path = Path()
-      ..moveTo(0, 0)
+      ..moveTo(-40, 00)
+      //remover  -0.1
+      // ..lineTo((loc - 0.1) * size.width, 0)
       ..lineTo((loc - 0.1) * size.width, 0)
       ..cubicTo(
         (loc + s * 0.20) * size.width,
@@ -38,8 +41,11 @@ class NavCustomPainter extends CustomPainter {
         size.height * 0.05,
         (loc + s + 0.1) * size.width,
         0,
+
+        // remover
+        // (loc + s ) * size.width,
       )
-      ..lineTo(size.width, 0)
+      ..lineTo(size.width + 40, 0)
       ..lineTo(size.width, size.height)
       ..lineTo(0, size.height)
       ..close();


### PR DESCRIPTION
Limit the maximum size of the menu.
with a new attribute maxWidth
if the screen is less than the **maxWidth** value, the menu takes the screen's Width value

![image](https://user-images.githubusercontent.com/10952239/201559729-a8a1e7f9-ca3e-4ce2-ad56-76f6158a6d19.png)


Removing the side leftovers from the menu.
Removing the side leftovers from the menu, because after limiting it, it creates leftovers on the sides